### PR TITLE
Handle 201 status code received from API.

### DIFF
--- a/src/main/java/com/runscope/jenkins/Runscope/RunscopeTrigger.java
+++ b/src/main/java/com/runscope/jenkins/Runscope/RunscopeTrigger.java
@@ -110,7 +110,7 @@ public class RunscopeTrigger implements Callable<String> {
             final HttpResponse response = future.get();
 
             final int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != 200) {
+            if (statusCode != 200 || statusCode != 201) {
               log.println(String.format("Error retrieving details from Runscope API, marking as failed: %s", statusCode));
               result = TEST_RESULTS_FAIL;
             } else {


### PR DESCRIPTION
The plugin is not working because currently runscope API responds with 201 code not 200.